### PR TITLE
Add Slack integration for ticket registration

### DIFF
--- a/tcamp/local_settings.example.py
+++ b/tcamp/local_settings.example.py
@@ -87,3 +87,5 @@ TWILIO_AUTH_TOKEN = ''
 RAVEN_CONFIG = {
     'dsn': '',
 }
+
+SLACK_TOKEN = ''

--- a/tcamp/slack.py
+++ b/tcamp/slack.py
@@ -1,0 +1,18 @@
+import json
+import requests
+from django.conf import settings
+
+USERNAME = 'tcampbot'
+URL = 'https://sunlight.slack.com/services/hooks/incoming-webhook'
+
+
+def post_registration(data):
+    text = '%s %s just registered for Transparency Camp!' % (data['first_name'], data['last_name'])
+    payload = {
+        'channel': '#transparencycamp',
+        'icon_emoji': 'tent',
+        'username': USERNAME,
+        'text': text
+    }
+    params = {'token': settings.SLACK_TOKEN}
+    requests.post(URL, params=params, data=json.dumps(payload))


### PR DESCRIPTION
I tested that slack.py works, but didn't run through an actual purchase. The call to post_registration is wrapped in a try:except because it should fail silently if it doesn't work.

SLACK_TOKEN will need to be added to local_settings.py on the server. I can pass along the token offline if this pr gets merged.
