### PR TITLE
more settings and make Slack optional

### DIFF
--- a/tcamp/local_settings.example.py
+++ b/tcamp/local_settings.example.py
@@ -88,4 +88,7 @@ RAVEN_CONFIG = {
     'dsn': '',
 }
 
+SLACK_ENABLED = False
+SLACK_URL = ''
 SLACK_TOKEN = ''
+SLACK_USERNAME = ''

--- a/tcamp/reg/views.py
+++ b/tcamp/reg/views.py
@@ -62,10 +62,6 @@ def save(request):
             form_response['success'] = True
             valid_tickets.append(form)
             types[int(form_data['type'])] += 1
-            try:
-                slack.post_registration(form.cleaned_data)
-            except:
-                pass
         else:
             out['success'] = False
             form_response['success'] = False
@@ -86,6 +82,12 @@ def save(request):
             ticket.save()
 
             tickets.append(ticket)
+
+            if settings.SLACK_ENABLED:
+                try:
+                    slack.post_registration(ticket)
+                except:
+                    pass
 
         # tickets are good, so confirm price
         price = get_price_data(tickets=types, coupon=data.get('coupon', None))

--- a/tcamp/slack.py
+++ b/tcamp/slack.py
@@ -2,17 +2,14 @@ import json
 import requests
 from django.conf import settings
 
-USERNAME = 'tcampbot'
-URL = 'https://sunlight.slack.com/services/hooks/incoming-webhook'
 
-
-def post_registration(data):
-    text = '%s %s just registered for Transparency Camp!' % (data['first_name'], data['last_name'])
+def post_registration(ticket):
+    text = '%s %s just registered for Transparency Camp!' % (ticket.first_name, ticket.last_name)
     payload = {
         'channel': '#transparencycamp',
         'icon_emoji': 'tent',
-        'username': USERNAME,
-        'text': text
+        'username': settings.SLACK_USERNAME,
+        'text': text,
     }
     params = {'token': settings.SLACK_TOKEN}
-    requests.post(URL, params=params, data=json.dumps(payload))
+    requests.post(settings.SLACK_URL, params=params, data=json.dumps(payload))


### PR DESCRIPTION
Per @drinks's request, moved stuff to settings and made Slack integration optional. Also moved the post_registration method call to the saved models instead of form creation.
